### PR TITLE
API e controller de ProductCategory

### DIFF
--- a/app/Http/Controllers/ProductCategoryController.php
+++ b/app/Http/Controllers/ProductCategoryController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Repositories\ProductsCategoriesRepository;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProductCategoryController extends Controller
+{
+    /**
+     * @var ProductsCategoriesRepository
+     */
+    protected $repository;
+
+    public function __construct(ProductsCategoriesRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function index()
+    {
+        return $this->repository->all();
+    }
+
+    /**
+     * @param Request $request
+     * @return mixed
+     */
+    public function create(Request $request)
+    {
+        return $this->repository->create($request->all());
+    }
+
+    /**
+     * @param $id
+     * @return JsonResponse
+     */
+    public function destroy($id)
+    {
+        if($this->repository->delete($id)) {
+            return new JsonResponse(['success' => true]);
+        }
+
+        return new JsonResponse(['success' => false]);
+    }
+
+    /**
+     * @param Request $request
+     * @param $id
+     * @return mixed
+     */
+    public function update(Request $request, $id)
+    {
+        return $this->repository->update($request->all(), $id);
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,6 @@ class VerifyCsrfToken extends BaseVerifier
      * @var array
      */
     protected $except = [
-        //
+        'api/*',
     ];
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -14,3 +14,8 @@
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/api/v1/products-categories', 'ProductCategoryController@index');
+Route::post('/api/v1/products-categories', 'ProductCategoryController@create');
+Route::put('/api/v1/products-categories/{id}', 'ProductCategoryController@update');
+Route::delete('/api/v1/products-categories/{id}', 'ProductCategoryController@destroy');

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Repositories\ProductsCategoriesRepository;
+use App\Repositories\ProductsCategoriesRepositoryEloquent;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +25,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->bind(
+            ProductsCategoriesRepository::class,
+            ProductsCategoriesRepositoryEloquent::class
+        );
     }
 }


### PR DESCRIPTION
API e controller de Product Category pronta, porém, sem qualquer eventual regra de negócio adicional além da persistência simples. Convém organizar o routes.php e criar grupos de rotas e analisar se de fato excluir essa rota da API da verificação de CSRF é a melhor solução.
